### PR TITLE
Added a setting to change the language transcribed by whisper

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,13 +54,19 @@
           "type": "string",
           "default": "en",
           "enum": [
-            "en",
-            "fr"
+            "af", "ar", "az", "be", "bg", "bs", "ca", "cs", "cy", "da", "de", "el", "en", "es", "et", 
+            "fi", "fr", "gl", "de", "el", "he", "hi", "hu", "is", "id", "it", "ja", "kk", "kn", "ko", 
+            "lv", "lt", "mi", "mk", "mr", "ms", "ne", "no", "fa", "pl", "pt", "ro", "ru", "sk", "sl", "sr", 
+            "sv", "sw", "ta", "th", "tl", "tr", "uk", "ur", "vi", "zh"
           ],
           "enumDescriptions": [
-            "English",
-            "French"
-          ],
+            "Afrikaans", "Arabic", "Azerbaijani", "Belarusian", "Bulgarian", "Bosnian", "Catalan", "Czech", "Welsh", 
+            "Danish", "German", "Greek", "English", "Spanish", "Estonian", "Persian", "Finnish", "French", "Galician", 
+            "Hebrew", "Hindi", "Croatian", "Hungarian", "Armenian", "Indonesian", "Icelandic", "Italian", "Japanese", 
+            "Kazakh", "Kannada", "Korean", "Lithuanian", "Latvian", "Maori", "Macedonian", "Marathi", "Malay", "Nepali", 
+            "Dutch", "Norwegian", "Polish", "Portuguese", "Romanian", "Russian", "Slovak", "Slovenian", "Serbian", 
+            "Swedish", "Swahili", "Tamil", "Thai", "Tagalog", "Turkish", "Ukrainian", "Urdu", "Vietnamese", "Chinese"
+          ],  
           "description": "The language to use for transcription"
         }
       }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,19 @@
             "large"
           ],
           "description": "Set the whisper model to use. Base is the default."
+        },
+        "whisperAssistant.transcriptionLanguage": {
+          "type": "string",
+          "default": "en",
+          "enum": [
+            "en",
+            "fr"
+          ],
+          "enumDescriptions": [
+            "English",
+            "French"
+          ],
+          "description": "The language to use for transcription"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,8 +136,9 @@ export async function toggleRecordingCommand(): Promise<void> {
 
         if (state.speechTranscription !== undefined) {
           const model: WhisperModel = getWhisperModel();
+          const language: string = getTranscriptionLanguage();
           const transcription: Transcription | undefined =
-            await state.speechTranscription.transcribeRecording(model);
+            await state.speechTranscription.transcribeRecording(model, language);
 
           if (transcription) {
             vscode.env.clipboard.writeText(transcription.text).then(() => {
@@ -257,6 +258,18 @@ function getWhisperModel(): WhisperModel {
   }
 
   return whisperModel;
+}
+
+function getTranscriptionLanguage(): string {
+  const config = vscode.workspace.getConfiguration('whisper-assistant');
+  const language = config.get('transcriptionLanguage') as string;
+  if (!language) {
+    state.outputChannel?.appendLine(
+      'Whisper Assistant: No transcription language found in configuration, using default (en)'
+    );
+    return 'en';
+  }
+  return language;
 }
 
 export function initializeOutputChannel(): void {

--- a/src/speech-transcription.ts
+++ b/src/speech-transcription.ts
@@ -80,15 +80,16 @@ class SpeechTranscription {
     this.recordingProcess = null;
   }
 
-  async transcribeRecording(
-    model: WhisperModel,
-  ): Promise<Transcription | undefined> {
+  public async transcribeRecording(model: WhisperModel, language: string): Promise<Transcription | undefined> {
     try {
+      const config = vscode.workspace.getConfiguration('whisperAssistant');
+      const language = config.get<string>('transcriptionLanguage', 'en');
+
       this.outputChannel.appendLine(
-        `Whisper Assistant: Transcribing recording using '${model}' model`,
+        `Whisper Assistant: Transcribing recording using '${model}' model and '${language}' language`,
       );
       const { stdout, stderr } = await execAsync(
-        `whisper ${this.outputDir}/${this.fileName}.wav --model ${model} --output_format json --task transcribe --language English --fp16 False --output_dir ${this.outputDir}`,
+        `whisper ${this.outputDir}/${this.fileName}.wav --model ${model} --output_format json --task transcribe --language ${language} --fp16 False --output_dir ${this.outputDir}`,
       );
       this.outputChannel.appendLine(
         `Whisper Assistant: Transcription: ${stdout}`,


### PR DESCRIPTION
Whisper understands many languages but automatically translates them into English, which is not necessarily the desired outcome. I added all the languages purportedly supported by whisper. I tested it in French, and with my very broken German, Spanish and Japanese. It seems to work. I did not test all the other languages.

Great extension by the way! Thanks! 