### PR TITLE
fix: Windows recording process termination and file handle issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "ctrlc-windows": "^2.2.0",
     "openai": "^4.90.0"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,7 +237,7 @@ export async function toggleRecordingCommand(): Promise<void> {
       } finally {
         // Always cleanup, even if there was an error
         if (state.speechTranscription !== undefined) {
-          state.speechTranscription.deleteFiles();
+          await state.speechTranscription.deleteFiles();
         }
         state.isTranscribing = false;
         state.recordingStartTime = undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,11 @@ css-what@^6.1.0:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
+ctrlc-windows@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ctrlc-windows/-/ctrlc-windows-2.2.0.tgz#bcd9e67029e32506083c9f2436e564e037fb2bde"
+  integrity sha512-t9y568r+T8FUuBaqKK60YGFJdj3b3ktdJW9WXIT3CuBdQhAOYdSZu75jFUN0Ay4Yz5HHicVQqAYCwcnqhOn23g==
+
 debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"


### PR DESCRIPTION
## Summary

This PR fixes critical issues with both sox and ffmpeg recording on Windows that prevented proper process termination and caused file handle problems.

### Issues Fixed
- Sox processes were left running after stopping recording on Windows
- Recording processes were force-killed before they could finalize WAV headers
- File handle locking prevented cleanup on Windows
- Transcription failed with empty files when using ffmpeg

### Solution
- Uses `ctrlc-windows` package to send proper CTRL-C signals to sox on Windows via the Windows `GenerateConsoleCtrlEvent` API
- Detects sox usage in both default and custom recording commands
- Recognizes Windows exit code 4294967295 (unsigned -1) as successful CTRL-C termination
- Adds file readiness checking before transcription to handle async file writes
- Makes file deletion async with Windows-specific delays to allow handle release
- Sets up exit listeners before termination to avoid race conditions

### Testing
**Tested by humans on Windows with both sox and ffmpeg. Both tools were broken before this fix:**
- ✅ Sox: Multiple successful recordings with proper transcriptions
- ✅ ffmpeg: Tested with Galaxy Buds3 Pro using DirectShow (dshow) input

Both recording methods now work correctly on Windows with graceful process termination and proper file handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)