### PR TITLE
feat: enable local microphone support in remote environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   "categories": [
     "Other"
   ],
+  "extensionKind": [
+    "ui"
+  ],
   "activationEvents": [
     "onStartupFinished",
     "onDidChangeWorkspaceFolders"


### PR DESCRIPTION
## Summary
- Forces the extension to run on the UI side (local machine) by adding `extensionKind: ["ui"]` to package.json
- Enables microphone access to work properly in remote SSH and WSL environments
- Allows users to use their local microphone while working in remote development environments

## Why This Change?
Remote environments (SSH, WSL) typically don't have direct access to audio devices. By forcing the extension to run on the UI side, the microphone recording happens on the local machine where the audio hardware is available, while the rest of the development environment remains remote.

## Test Plan
- [x] Test extension in local environment (should work as before)
- [x] Test extension in remote SSH environment (microphone should work)
- [x] Test extension in WSL environment (microphone should work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)